### PR TITLE
add option to use PPA repository instead of official nginx repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@ This cookbook installs the Nginx components if not present, and pulls updates if
 ## Attributes
 
 ```ruby
-default["nginx"]["dir"]      = "/etc/nginx"
-default["nginx"]["log_dir"]  = "/var/log/nginx"
-default["nginx"]["user"]     = "www-data"
-default["nginx"]["binary"]   = "/usr/sbin/nginx"
-default["nginx"]["pid_file"] = "/var/run/nginx.pid"
-default["nginx"]["version"]  = nil
+default["nginx"]["dir"]        = "/etc/nginx"
+default["nginx"]["log_dir"]    = "/var/log/nginx"
+default["nginx"]["user"]       = "www-data"
+default["nginx"]["binary"]     = "/usr/sbin/nginx"
+default["nginx"]["pid_file"]   = "/var/run/nginx.pid"
+default["nginx"]["version"]    = nil
+default["nginx"]["repository"] = "official" # or, "ppa"
 
 default["nginx"]["log_format"] = <<-FORMAT
   '$remote_addr $host $remote_user [$time_local] "$request" '

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,12 +7,13 @@
 # Copyright 2013, Phil Cohen
 #
 
-default["nginx"]["dir"]      = "/etc/nginx"
-default["nginx"]["log_dir"]  = "/var/log/nginx"
-default["nginx"]["user"]     = "www-data"
-default["nginx"]["binary"]   = "/usr/sbin/nginx"
-default["nginx"]["pid_file"] = "/var/run/nginx.pid"
-default["nginx"]["version"]  = nil
+default["nginx"]["dir"]        = "/etc/nginx"
+default["nginx"]["log_dir"]    = "/var/log/nginx"
+default["nginx"]["user"]       = "www-data"
+default["nginx"]["binary"]     = "/usr/sbin/nginx"
+default["nginx"]["pid_file"]   = "/var/run/nginx.pid"
+default["nginx"]["version"]    = nil
+default["nginx"]["repository"] = "official"
 
 default["nginx"]["log_format"] = <<-FORMAT
   '$remote_addr $host $remote_user [$time_local] "$request" '

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,10 +4,26 @@
 #
 # Copyright 2013, Phil Cohen <github@phlippers.net>
 
-apt_repository "nginx" do
-  uri "http://nginx.org/packages/#{node["platform"]}"
-  distribution node["lsb"]["codename"]
-  components ["nginx"]
-  action :add
-  key "http://nginx.org/keys/nginx_signing.key"
+if node["nginx"]["repository"] == "official"
+
+  apt_repository "nginx" do
+    uri "http://nginx.org/packages/#{node["platform"]}"
+    distribution node["lsb"]["codename"]
+    components ["nginx"]
+    action :add
+    key "http://nginx.org/keys/nginx_signing.key"
+  end
+
+elsif node["nginx"]["repository"] == "ppa"
+
+  apt_repository "nginx" do
+    uri "http://ppa.launchpad.net/nginx/stable/ubuntu"
+    distribution node["lsb"]["codename"]
+    components ["main"]
+    action :add
+    keyserver "keyserver.ubuntu.com"
+    key "C300EE8C"
+    deb_src true
+  end
+
 end


### PR DESCRIPTION
I had trouble getting the official repository to work. I'm not sure what the root problem was, but the PPA repository worked so I figured it would be nice to provide an easy way to use it. Also, setting the `repository` attribute to nil should skip the repository setup (might help someone).

Valid options for the `repository` attribute are:
- `official` original nginx repository
- `ppa` volunteer ppa repository
