### PR TITLE
New lwrp input for custom data for overridden template

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ Attribute Parameters (only used with the `create` action):
 * `location` - basic [location](http://nginx.org/en/docs/http/ngx_http_core_module.html#location) block configuration, defaults to 'try_files $uri $uri/'
 * `phpfpm` - inserts a basic php fpm handler for .php files if true, defaults to false
 * `access_log` - enable or disable the access log, defaults to true
+* `custom` - hash of extra data for any custom things you might throw into your override template, defaults to an empty hash
 * `template_cookbook` - allows you to override the template used with your own. Set this to your cookbook name and create a template named 'site.erb', defaults to 'nginx'
 * `template_source` - override for the name of the template from the default 'site.erb'
-* `custom` - array of extra data for any custom things you might throw into your override template
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -109,6 +109,21 @@ end
 
 This would create a php-fpm enabled virtual host (provided you have php-fpm installed) with a default rewrite to index.php and enable it
 
+```ruby
+my_data = { 'env' => 'production' }
+
+nginx_site "example.com" do
+  host "example.com www.example.com"
+  root "/var/www/example.com"
+  custom_data my_data
+  template_cookbook 'my_cookbook'
+  template_source 'my.conf.erb'
+  action [:create, :enable]
+end
+```
+
+This would create a virtual host using your own custom template ´my.conf.erb´ in the cookbook ´my_cookbook´. The contents of ´my_data´ will be available in the template, thus writing ´@custom_data['environment']´ in your template will yield ´production´ in this example. And as with the previous examples `:enable` will make the site enabled.
+
 
 ## Attributes
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Attribute Parameters (only used with the `create` action):
 * `access_log` - enable or disable the access log, defaults to true
 * `template_cookbook` - allows you to override the template used with your own. Set this to your cookbook name and create a template named 'site.erb', defaults to 'nginx'
 * `template_source` - override for the name of the template from the default 'site.erb'
+* `custom` - array of extra data for any custom things you might throw into your override template
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Attribute Parameters (only used with the `create` action):
 * `location` - basic [location](http://nginx.org/en/docs/http/ngx_http_core_module.html#location) block configuration, defaults to 'try_files $uri $uri/'
 * `phpfpm` - inserts a basic php fpm handler for .php files if true, defaults to false
 * `access_log` - enable or disable the access log, defaults to true
-* `custom` - hash of extra data for any custom things you might throw into your override template, defaults to an empty hash
+* `custom_data` - hash of extra data for any custom things you might throw into your override template, defaults to an empty hash
 * `template_cookbook` - allows you to override the template used with your own. Set this to your cookbook name and create a template named 'site.erb', defaults to 'nginx'
 * `template_source` - override for the name of the template from the default 'site.erb'
 

--- a/providers/site.rb
+++ b/providers/site.rb
@@ -25,7 +25,7 @@ action :create do
       location: new_resource.location,
       phpfpm: new_resource.phpfpm,
       access_log: new_resource.access_log,
-      custom: new_resource.custom
+      custom_data: new_resource.custom_data
     )
   end
 end

--- a/providers/site.rb
+++ b/providers/site.rb
@@ -24,7 +24,8 @@ action :create do
       index: new_resource.index,
       location: new_resource.location,
       phpfpm: new_resource.phpfpm,
-      access_log: new_resource.access_log
+      access_log: new_resource.access_log,
+      custom: new_resource.custom
     )
   end
 end

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -15,6 +15,7 @@ attribute :index, kind_of: String, default: "index.html index.htm"
 attribute :location, kind_of: String, default: "try_files $uri $uri/"
 attribute :phpfpm, kind_of: [TrueClass, FalseClass], default: false
 attribute :access_log, kind_of: [TrueClass, FalseClass], default: true
+attribute :custom, kind_of: Array, default: []
 attribute :template_cookbook, kind_of: String, default: "nginx"
 attribute :template_source, kind_of: String, default: "site.erb"
 

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -15,7 +15,7 @@ attribute :index, kind_of: String, default: "index.html index.htm"
 attribute :location, kind_of: String, default: "try_files $uri $uri/"
 attribute :phpfpm, kind_of: [TrueClass, FalseClass], default: false
 attribute :access_log, kind_of: [TrueClass, FalseClass], default: true
-attribute :custom, kind_of: Array, default: []
+attribute :custom, kind_of: Hash, default: {}
 attribute :template_cookbook, kind_of: String, default: "nginx"
 attribute :template_source, kind_of: String, default: "site.erb"
 

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -15,7 +15,7 @@ attribute :index, kind_of: String, default: "index.html index.htm"
 attribute :location, kind_of: String, default: "try_files $uri $uri/"
 attribute :phpfpm, kind_of: [TrueClass, FalseClass], default: false
 attribute :access_log, kind_of: [TrueClass, FalseClass], default: true
-attribute :custom, kind_of: Hash, default: {}
+attribute :custom_data, kind_of: Hash, default: {}
 attribute :template_cookbook, kind_of: String, default: "nginx"
 attribute :template_source, kind_of: String, default: "site.erb"
 


### PR DESCRIPTION
If you have your own template having an additional unused input to the lwrp that is sent to the template would be very useful and make the template override feature much better.

This pull request also includes an example of template override for the README.