### PR TITLE
Add Passenger configuration to base Nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ default["nginx"]["user"]       = "www-data"
 default['nginx']["bin_dir"]    = "/usr/sbin"
 default["nginx"]["binary"]     = "/usr/sbin/nginx"
 default["nginx"]["pid_file"]   = "/var/run/nginx.pid"
+default["nginx"]["purge_old"]  = false # purges all installed versions of nginx via apt-get purge
 default["nginx"]["version"]    = nil
 default["nginx"]["package_name"] = "nginx"  # nginx[-light|full|extras]
 
@@ -204,8 +205,12 @@ default["nginx"]["ssl_session_cache"]        = "shared:SSL:10m"
 default["nginx"]["ssl_session_timeout"]      = "10m"
 
 default["nginx"]["passenger_enable"]         = false
-default["nginx"]["passenger_max_pool_size"]  = 6
-default["nginx"]["passenger_pool_idle_time"] = 300
+default["nginx"]["passenger_ruby"]           = nil # if nil, uses `which ruby`
+default["nginx"]["passenger_config"]         = {
+  "passenger_pool_idle_time" => 300,
+  "passenger_max_pool_size"  => 6
+}
+default["nginx"]["passenger_headers"]        = {}
 
 default["nginx"]["enable_stub_status"] = true
 default["nginx"]["status_port"]        = 80

--- a/README.md
+++ b/README.md
@@ -210,7 +210,12 @@ default["nginx"]["passenger_config"]         = {
   "passenger_pool_idle_time" => 300,
   "passenger_max_pool_size"  => 6
 }
-default["nginx"]["passenger_headers"]        = {}
+default["nginx"]["passenger_headers"]        = {
+  # "X-Forwarded-For" => "$http_x_forwarded_for"
+}
+default["nginx"]["passenger_prestart_urls"]  = [
+  # "http://myawesomeapp.com:81/"
+]
 
 default["nginx"]["enable_stub_status"] = true
 default["nginx"]["status_port"]        = 80

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ default["nginx"]["status_port"]        = 80
 
 default["nginx"]["skip_default_site"]  = false
 
+default["nginx"]["skip_default_mime_types"] = false
+
 default["nginx"]["repository"] = "official"
 default["nginx"]["repository_sources"] = {
   "official" => {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,7 @@ default["nginx"]["user"]       = "www-data"
 default["nginx"]["bin_dir"]    = "/usr/sbin"
 default["nginx"]["binary"]     = "/usr/sbin/nginx"
 default["nginx"]["pid_file"]   = "/var/run/nginx.pid"
+default["nginx"]["purge_old"]  = false # purges all installed versions of nginx via apt-get purge
 default["nginx"]["version"]    = nil
 default["nginx"]["package_name"] = "nginx"  # nginx[-light|full|extras]
 
@@ -84,8 +85,12 @@ default["nginx"]["ssl_session_cache"]        = "shared:SSL:10m"
 default["nginx"]["ssl_session_timeout"]      = "10m"
 
 default["nginx"]["passenger_enable"]         = false
-default["nginx"]["passenger_max_pool_size"]  = 6
-default["nginx"]["passenger_pool_idle_time"] = 300
+default["nginx"]["passenger_ruby"]           = nil # if nil, uses `which ruby`
+default["nginx"]["passenger_config"]         = {
+  "passenger_pool_idle_time" => 300,
+  "passenger_max_pool_size"  => 6
+}
+default["nginx"]["passenger_headers"]        = {}
 
 default["nginx"]["enable_stub_status"] = true
 default["nginx"]["status_port"]        = 80

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -97,6 +97,8 @@ default["nginx"]["status_port"]        = 80
 
 default["nginx"]["skip_default_site"]  = false
 
+default["nginx"]["skip_default_mime_types"] = false
+
 default["nginx"]["repository"] = "official"
 default["nginx"]["repository_sources"] = {
   "official" => {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -90,7 +90,12 @@ default["nginx"]["passenger_config"]         = {
   "passenger_pool_idle_time" => 300,
   "passenger_max_pool_size"  => 6
 }
-default["nginx"]["passenger_headers"]        = {}
+default["nginx"]["passenger_headers"]        = {
+  # "X-Forwarded-For" => "$http_x_forwarded_for"
+}
+default["nginx"]["passenger_prestart_urls"]  = [
+  # "http://myawesomeapp.com:81/"
+]
 
 default["nginx"]["enable_stub_status"] = true
 default["nginx"]["status_port"]        = 80

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "github@phlippers.net"
 license          "MIT"
 description      "Installs/configures nginx"
 long_description "Please refer to README.md"
-version          "0.6.0"
+version          "0.6.1"
 
 recipe "nginx", "The default recipe which sets up the repository."
 recipe "nginx::configuration", "Internal recipe to setup the configuration files."

--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -18,6 +18,7 @@ cookbook_file "#{node["nginx"]["dir"]}/mime.types" do
   group "root"
   mode  "0644"
   notifies :restart, "service[nginx]"
+  not_if { node["nginx"]["skip_default_mime_types"] }
 end
 
 template "nginx.conf" do

--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -73,3 +73,12 @@ template "#{node["nginx"]["dir"]}/conf.d/nginx_status.conf" do
   variables(port: node["nginx"]["status_port"])
   only_if { node["nginx"]["enable_stub_status"] }
 end
+
+template "#{node["nginx"]["dir"]}/conf.d/passenger.conf" do
+  source "passenger.conf.erb"
+  owner  "root"
+  group  "root"
+  mode   "0644"
+  notifies :restart, "service[nginx]"
+  only_if { node["nginx"]["passenger_enable"] }
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,6 +3,8 @@
 # Recipe:: default
 #
 
+include_recipe "nginx::purge_old_versions"
+
 repo = node["nginx"]["repository_sources"].fetch(node["nginx"]["repository"])
 
 apt_repository "nginx" do

--- a/recipes/purge_old_versions.rb
+++ b/recipes/purge_old_versions.rb
@@ -1,0 +1,11 @@
+#
+# Cookbook Name:: nginx
+# Recipe:: purge_old_versions
+#
+
+%w(nginx nginx-light nginx-naxsi nginx-common passenger nginx-extras passenger-enterprise nginx-full).each do |pkg|
+  apt_package pkg do
+    action :purge
+    only_if { node['nginx']['purge_old'] }
+  end
+end

--- a/templates/default/passenger.conf.erb
+++ b/templates/default/passenger.conf.erb
@@ -13,3 +13,8 @@ passenger_ruby <%= node["nginx"]["passenger_ruby"] || `which ruby`.strip %>;
 <% node["nginx"]["passenger_headers"].each do |key, value| %>
 passenger_set_header <%= key %> <%= value %>;
 <% end %>
+
+# Prestart URLs
+<% node["nginx"]["passenger_prestart_urls"].each do |url| %>
+passenger_pre_start <%= url %>;
+<% end %>

--- a/templates/default/passenger.conf.erb
+++ b/templates/default/passenger.conf.erb
@@ -1,0 +1,15 @@
+# Passenger Root
+passenger_root <%= `/usr/bin/passenger-config --root`.strip %>;
+
+# Default ruby to use
+passenger_ruby <%= node["nginx"]["passenger_ruby"] || `which ruby`.strip %>;
+
+# Default config settings
+<% node["nginx"]["passenger_config"].each do |key, value| %>
+<%= key %> <%= value %>;
+<% end %>
+
+# Default Headers to send
+<% node["nginx"]["passenger_headers"].each do |key, value| %>
+passenger_set_header <%= key %> <%= value %>;
+<% end %>


### PR DESCRIPTION
This PR adds base level configuration support for Passenger settings, headers, and pre-start urls.

The purpose of this is to be able to setup Nginx to use Passenger by default and to enable setup of sane defaults for all passenger apps running within Nginx.

I also added a `default['nginx']['purge_old']` attribute to force apt-get to purge all existing nginx packages on a box. When set to `true` it will allow you to upgrade from the "official" to the "phusion" version of the Nginx package if you need to deploy Passenger on existing machines running without Passenger support.
