### PR TITLE
Fix for possibly interrupted nginx-common instalation

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -5,14 +5,12 @@
 
 include_recipe "nginx"
 
-# ensure config files don't get trampled by chef
-package "nginx-common" do
-  options %(-o Dpkg::Options::="--force-confdef")
-  only_if { %w[ppa phusion].include?(node["nginx"]["repository"]) }
-end
-
 package node["nginx"]["package_name"] do
   version node["nginx"]["version"]
+  
+  # ensure config files don't get trampled by chef
+  options %(-o Dpkg::Options::="--force-confdef")
+  only_if { %w[ppa phusion].include?(node["nginx"]["repository"]) }
 end
 
 include_recipe "nginx::service"


### PR DESCRIPTION
I've moved `Dpkg::Options::="--force-confdef"` down to `nginx` installation instead of `nginx-common` only. 
My case was installing `nginx` with version specified on the box with an earlier `nginx` version already installed. 

Before that change, the recipe tried to install package `nginx-common` without specifying its version, and it was reported as up to date. 
Then, `nginx` with specific version was installed and `nginx-common` was reported as needing update. During the update the prompt asking what to do with config appeared, [like this](http://opsrobot.com/post/22784291838/chef-install-apt-packages-when-apt-requires), because the `--force-confdef` option was not passed down here, and all the installation failed at unresolved dependencies.
