### PR TITLE
CentOS + Rubocop updates

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   require_chef_omnibus: <%= ENV.fetch("CHEF_VERSION", "latest") %>
-  ssh_key: <%= File.expand_path("./test/support/keys/vagrant") %>
+  #ssh_key: <%= File.expand_path("./test/support/keys/vagrant") %>
   name: vagrant
 
 provisioner:
@@ -12,6 +12,7 @@ platforms:
   - name: ubuntu-14.04
   - name: debian-6.0.8
   - name: debian-7.4
+  - name: centos-6.7
 
 suites:
   - name: server

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
 LineLength:
   Max: 200
 
+Style/RegexpLiteral:
+  Exclude:
+    - 'Guardfile'
+
 PercentLiteralDelimiters:
   PreferredDelimiters:
     "%w": "[]"  # Arrays use brackets

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,20 +1,11 @@
 LineLength:
-  Max: 80
-  Exclude:
-    - "**/attributes/*.rb"
-    - "**/metadata.rb"
-
-StringLiterals:
-  EnforcedStyle: double_quotes
-
-StringLiteralsInInterpolation:
-  EnforcedStyle: double_quotes
+  Max: 200
 
 PercentLiteralDelimiters:
   PreferredDelimiters:
     "%w": "[]"  # Arrays use brackets
 
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false  # too strict about metadata and certain formatting
 
 inherit_from: test/support/rubocop/enabled.yml

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source "https://api.berkshelf.com"
+source 'https://api.berkshelf.com'
 
 metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file is used to list changes made in each version of nginx.
 
+## 0.7.0 (2016-04-06)
+
+* Support for CentOS, tested against CentOS 6.7
+* Verify test coverage on CentOS
+* Removed ssh configuration in kitchen, files not included with repo
+* Rubocop changes
+  * Max Line Length = 200
+  * Change " to ' and replace interpolation and quoting rubocop lines
+
 ## 0.6.0 (2015-01-17)
 
 * Add `nginx_site` LWRP

--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,18 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-chef_version = ENV.fetch("CHEF_VERSION", "11.16")
+chef_version = ENV.fetch('CHEF_VERSION', '11.16')
 
-gem "chef", "~> #{chef_version}"
-gem "chefspec", "~> 4.2.0" if chef_version =~ /^11/
+gem 'chef', "~> #{chef_version}"
+gem 'chefspec', '~> 4.2.0' if chef_version =~ /^11/
 
-gem "berkshelf", "~> 3.2.1"
-gem "foodcritic", "~> 4.0.0"
-gem "rake"
-gem "rubocop", "~> 0.28.0"
-gem "serverspec", "~> 2.7.1"
+gem 'berkshelf', '~> 3.2.1'
+gem 'foodcritic', '~> 4.0.0'
+gem 'rake'
+gem 'rubocop', '~> 0.28.0'
+gem 'serverspec', '~> 2.7.1'
 
 group :integration do
-  gem "busser-serverspec", "~> 0.5.3"
-  gem "kitchen-vagrant", "~> 0.15.0"
-  gem "test-kitchen", "~> 1.3.1"
+  gem 'busser-serverspec', '~> 0.5.3'
+  gem 'kitchen-vagrant', '~> 0.15.0'
+  gem 'test-kitchen', '~> 1.3.1'
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,6 @@
-guard :rspec, cmd: "rspec --color", all_on_start: false do
-  watch(/^spec\/(.+)_spec\.rb$/)
-  watch(/^recipes\/(.+)\.rb$/) { |m| "spec/#{m[1]}_spec.rb" }
-  watch("spec/spec_helper.rb") { "spec" }
+guard :rspec, cmd: 'rspec --color', all_on_start: false do
+  # watch(/^spec\/(.+)_spec\.rb$/)
+  watch(%r{^spec/(.+)_spec\.rb$})
+  watch(%r{^recipes/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb') { 'spec' }
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,6 +1,6 @@
 guard :rspec, cmd: 'rspec --color', all_on_start: false do
   # watch(/^spec\/(.+)_spec\.rb$/)
-  watch(%r{^spec/(.+)_spec\.rb$})
-  watch(%r{^recipes/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
+  watch(/^spec\/(.+)_spec\.rb$/)
+  watch(/^recipes\/(.+)\.rb$/) { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb') { 'spec' }
 end

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ recipes should run on these platforms without error:
 
 ### Cookbooks
 
-* [apt](http://community.opscode.com/cookbooks/apt) Opscode LWRP Cookbook
+* [apt](http://supermarket.chef.io/cookbooks/apt) - apt Cookbook
+* [yum](http://supermarket.chef.io/cookbooks/yum) - yum Cookbook
+* [yum-nginx](http://supermarket.chef.io/cookbooks/yum-nginx) - yum-nginx Cookbook
 
 ### Chef
 
@@ -286,6 +288,8 @@ Many thanks go to the following [contributors](https://github.com/phlipper/chef-
     * Script for enabling and disabling sites, added and renamed by [@arvidbjorkstrom](https://github.com/arvidbjorkstrom)
 * **[@morr](https://github.com/morr)**
     * update `mime.types` to support web fonts correctly
+* **[@mengesb](https://github.com/mengesb)**
+    * add CentOS support
 
 
 ## License

--- a/Rakefile
+++ b/Rakefile
@@ -1,31 +1,31 @@
-task default: "test"
+task default: 'test'
 
-desc "Run all tests except `kitchen`"
+desc 'Run all tests except `kitchen`'
 task test: [:rubocop, :foodcritic, :chefspec]
 
-desc "Run all tests"
-task all_tests: [:rubocop, :foodcritic, :chefspec, "kitchen:all"]
+desc 'Run all tests'
+task all_tests: [:rubocop, :foodcritic, :chefspec, 'kitchen:all']
 
 # rubocop style checker
-require "rubocop/rake_task"
+require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
 # foodcritic chef lint
-require "foodcritic"
+require 'foodcritic'
 FoodCritic::Rake::LintTask.new do |t|
-  t.options = { fail_tags: ["any"] }
+  t.options = { fail_tags: ['any'] }
 end
 
 # chefspec unit tests
-require "rspec/core/rake_task"
+require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:chefspec) do |t|
-  t.rspec_opts = "--color --format progress"
+  t.rspec_opts = '--color --format progress'
 end
 
 # test-kitchen integration tests
 begin
-  require "kitchen/rake_tasks"
+  require 'kitchen/rake_tasks'
   Kitchen::RakeTasks.new
 rescue LoadError
-  task("kitchen:all") { puts "Unable to run `test-kitchen`" }
+  task('kitchen:all') { puts 'Unable to run `test-kitchen`' }
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,117 +7,129 @@
 # Copyright 2013, Phil Cohen
 #
 
-default["nginx"]["dir"]        = "/etc/nginx"
-default["nginx"]["log_dir"]    = "/var/log/nginx"
-default["nginx"]["user"]       = "www-data"
-default["nginx"]["bin_dir"]    = "/usr/sbin"
-default["nginx"]["binary"]     = "/usr/sbin/nginx"
-default["nginx"]["pid_file"]   = "/var/run/nginx.pid"
-default["nginx"]["version"]    = nil
-default["nginx"]["package_name"] = "nginx"  # nginx[-light|full|extras]
+case node['platform_family']
+when 'debian'
+  default['nginx']['user']     = 'www-data'
+  default['nginx']['group']    = 'www-data'
+when 'rhel'
+  default['nginx']['user']     = 'nginx'
+  default['nginx']['group']    = 'nginx'
+else
+  default['nginx']['user']     = 'www-data'
+  default['nginx']['group']    = 'www-data'
+end
 
-default["nginx"]["log_format"] = <<-FORMAT
+default['nginx']['dir']        = '/etc/nginx'
+default['nginx']['log_dir']    = '/var/log/nginx'
+# default["nginx"]["user"]       = "www-data"
+default['nginx']['bin_dir']    = '/usr/sbin'
+default['nginx']['binary']     = '/usr/sbin/nginx'
+default['nginx']['pid_file']   = '/var/run/nginx.pid'
+default['nginx']['version']    = nil
+default['nginx']['package_name'] = 'nginx' # nginx[-light|full|extras]
+
+default['nginx']['log_format'] = <<-FORMAT
   '$remote_addr $host $remote_user [$time_local] "$request" '
   '$status $body_bytes_sent "$http_referer" "$http_user_agent" "$gzip_ratio"'
 FORMAT
 
-default["nginx"]["daemon_disable"] = false
+default['nginx']['daemon_disable'] = false
 
-default["nginx"]["use_poll"] = true
+default['nginx']['use_poll'] = true
 
-default["nginx"]["gzip"]              = "on"
-default["nginx"]["gzip_http_version"] = "1.0"
-default["nginx"]["gzip_buffers"]      = "16 8k"
-default["nginx"]["gzip_comp_level"]   = "2"
-default["nginx"]["gzip_proxied"]      = "any"
-default["nginx"]["gzip_vary"]         = "on"
-default["nginx"]["gzip_min_length"]   = "0"
-default["nginx"]["gzip_disable"]      = %|"MSIE [1-6].(?!.*SV1)"|
-default["nginx"]["gzip_types"]        = %w[
+default['nginx']['gzip']              = 'on'
+default['nginx']['gzip_http_version'] = '1.0'
+default['nginx']['gzip_buffers']      = '16 8k'
+default['nginx']['gzip_comp_level']   = '2'
+default['nginx']['gzip_proxied']      = 'any'
+default['nginx']['gzip_vary']         = 'on'
+default['nginx']['gzip_min_length']   = '0'
+default['nginx']['gzip_disable']      = %|"MSIE [1-6].(?!.*SV1)"|
+default['nginx']['gzip_types']        = %w[
   text/css text/javascript text/xml text/plain text/x-component
   application/x-javascript application/javascript application/json
   application/xml application/rss+xml image/svg+xml
   font/truetype font/opentype application/vnd.ms-fontobject
 ]
 
-default["nginx"]["ignore_invalid_headers"]      = "on"
-default["nginx"]["recursive_error_pages"]       = "on"
-default["nginx"]["sendfile"]                    = "on"
-default["nginx"]["server_name_in_redirect"]     = "off"
-default["nginx"]["server_tokens"]               = "off"
+default['nginx']['ignore_invalid_headers']      = 'on'
+default['nginx']['recursive_error_pages']       = 'on'
+default['nginx']['sendfile']                    = 'on'
+default['nginx']['server_name_in_redirect']     = 'off'
+default['nginx']['server_tokens']               = 'off'
 
-default["nginx"]["buffers_enable"]              = false
-default["nginx"]["client_body_temp_path"]       = "/var/spool/nginx-client-body 1 2"
-default["nginx"]["client_body_buffer_size"]     = "8k"
-default["nginx"]["client_header_buffer_size"]   = "1k"
-default["nginx"]["client_max_body_size"]        = "1m"
-default["nginx"]["large_client_header_buffers"] = "4 8k"
+default['nginx']['buffers_enable']              = false
+default['nginx']['client_body_temp_path']       = '/var/spool/nginx-client-body 1 2'
+default['nginx']['client_body_buffer_size']     = '8k'
+default['nginx']['client_header_buffer_size']   = '1k'
+default['nginx']['client_max_body_size']        = '1m'
+default['nginx']['large_client_header_buffers'] = '4 8k'
 
-default["nginx"]["tcp_nopush"]  = "on"
-default["nginx"]["tcp_nodelay"] = "off"
+default['nginx']['tcp_nopush']  = 'on'
+default['nginx']['tcp_nodelay'] = 'off'
 
-default["nginx"]["proxy_set_headers"] = [
-  "X-Real-IP $remote_addr",
-  "X-Forwarded-For $proxy_add_x_forwarded_for",
-  "Host $http_host"
+default['nginx']['proxy_set_headers'] = [
+  'X-Real-IP $remote_addr',
+  'X-Forwarded-For $proxy_add_x_forwarded_for',
+  'Host $http_host'
 ]
-default["nginx"]["proxy_redirect"] = "off"
-default["nginx"]["proxy_max_temp_file_size"] = nil
-default["nginx"]["proxy_read_timeout"] = nil
+default['nginx']['proxy_redirect'] = 'off'
+default['nginx']['proxy_max_temp_file_size'] = nil
+default['nginx']['proxy_read_timeout'] = nil
 
-default["nginx"]["keepalive"]             = "on"
-default["nginx"]["keepalive_timeout"]     = 65
-default["nginx"]["send_timeout"]          = 5
-default["nginx"]["client_header_timeout"] = 5
-default["nginx"]["client_body_timeout"]   = 5
+default['nginx']['keepalive']             = 'on'
+default['nginx']['keepalive_timeout']     = 65
+default['nginx']['send_timeout']          = 5
+default['nginx']['client_header_timeout'] = 5
+default['nginx']['client_body_timeout']   = 5
 
-default["nginx"]["worker_processes"]   = node["cpu"]["total"]
-default["nginx"]["worker_connections"] = node["cpu"]["total"].to_i * 1024
-default["nginx"]["server_names_hash_bucket_size"] = 64
+default['nginx']['worker_processes']   = node['cpu']['total']
+default['nginx']['worker_connections'] = node['cpu']['total'].to_i * 1024
+default['nginx']['server_names_hash_bucket_size'] = 64
 
-default["nginx"]["conf_files"] = %w[
+default['nginx']['conf_files'] = %w[
   buffers general gzip logs performance proxy ssl_session timeouts
 ]
 
-default["nginx"]["ssl_session_cache_enable"] = true
-default["nginx"]["ssl_session_cache"]        = "shared:SSL:10m"
-default["nginx"]["ssl_session_timeout"]      = "10m"
+default['nginx']['ssl_session_cache_enable'] = true
+default['nginx']['ssl_session_cache']        = 'shared:SSL:10m'
+default['nginx']['ssl_session_timeout']      = '10m'
 
-default["nginx"]["passenger_enable"]         = false
-default["nginx"]["passenger_max_pool_size"]  = 6
-default["nginx"]["passenger_pool_idle_time"] = 300
+default['nginx']['passenger_enable']         = false
+default['nginx']['passenger_max_pool_size']  = 6
+default['nginx']['passenger_pool_idle_time'] = 300
 
-default["nginx"]["enable_stub_status"] = true
-default["nginx"]["status_port"]        = 80
+default['nginx']['enable_stub_status'] = true
+default['nginx']['status_port']        = 80
 
-default["nginx"]["skip_default_site"]  = false
+default['nginx']['skip_default_site']  = false
 
-default["nginx"]["repository"] = "official"
-default["nginx"]["repository_sources"] = {
-  "official" => {
-    "uri"          => "http://nginx.org/packages/#{node["platform"]}",
-    "distribution" => node["lsb"]["codename"],
-    "components"   => ["nginx"],
-    "keyserver"    => nil,
-    "key"          => "http://nginx.org/keys/nginx_signing.key",
-    "deb_src"      => false
+default['nginx']['repository'] = 'official'
+default['nginx']['repository_sources'] = {
+  'official' => {
+    'uri'          => "http://nginx.org/packages/#{node['platform']}",
+    'distribution' => node['lsb']['codename'],
+    'components'   => ['nginx'],
+    'keyserver'    => nil,
+    'key'          => 'http://nginx.org/keys/nginx_signing.key',
+    'deb_src'      => false
   },
 
-  "ppa" => {
-    "uri"          => "http://ppa.launchpad.net/nginx/stable/ubuntu",
-    "distribution" => node["lsb"]["codename"],
-    "components"   => ["main"],
-    "keyserver"    => "keyserver.ubuntu.com",
-    "key"          => "C300EE8C",
-    "deb_src"      => true
+  'ppa' => {
+    'uri'          => 'http://ppa.launchpad.net/nginx/stable/ubuntu',
+    'distribution' => node['lsb']['codename'],
+    'components'   => ['main'],
+    'keyserver'    => 'keyserver.ubuntu.com',
+    'key'          => 'C300EE8C',
+    'deb_src'      => true
   },
 
-  "phusion" => {
-    "uri"          => "https://oss-binaries.phusionpassenger.com/apt/passenger",
-    "distribution" => node["lsb"]["codename"],
-    "components"   => ["main"],
-    "keyserver"    => "keyserver.ubuntu.com",
-    "key"          => "561F9B9CAC40B2F7",
-    "deb_src"      => true
+  'phusion' => {
+    'uri'          => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
+    'distribution' => node['lsb']['codename'],
+    'components'   => ['main'],
+    'keyserver'    => 'keyserver.ubuntu.com',
+    'key'          => '561F9B9CAC40B2F7',
+    'deb_src'      => true
   }
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,18 +1,21 @@
-name             "nginx"
-maintainer       "Phil Cohen"
-maintainer_email "github@phlippers.net"
-license          "MIT"
-description      "Installs/configures nginx"
-long_description "Please refer to README.md"
-version          "0.6.0"
+name 'nginx'
+maintainer 'Phil Cohen'
+maintainer_email 'github@phlippers.net'
+license 'MIT'
+description 'Installs/configures nginx'
+long_description 'Please refer to README.md'
+version '0.7.0'
 
-recipe "nginx", "The default recipe which sets up the repository."
-recipe "nginx::configuration", "Internal recipe to setup the configuration files."
-recipe "nginx::service", "Internal recipe to setup the service definition."
-recipe "nginx::server", "Install and configure the `nginx` package."
-recipe "nginx::debug", "Install and configure the `nginx-debug` package."
+recipe 'nginx', 'The default recipe which sets up the repository.'
+recipe 'nginx::configuration', 'Internal recipe to setup the configuration files.'
+recipe 'nginx::service', 'Internal recipe to setup the service definition.'
+recipe 'nginx::server', 'Install and configure the `nginx` package.'
+recipe 'nginx::debug', 'Install and configure the `nginx-debug` package.'
 
-depends "apt"
+depends 'apt'
+depends 'yum'
+depends 'yum-nginx'
 
-supports "debian"
-supports "ubuntu"
+supports 'debian'
+supports 'ubuntu'
+supports 'centos'

--- a/providers/site.rb
+++ b/providers/site.rb
@@ -13,9 +13,9 @@ action :create do
   template nginx_available_file do
     source new_resource.template_source
     cookbook new_resource.template_cookbook
-    owner "root"
-    group "root"
-    mode "0644"
+    owner 'root'
+    group 'root'
+    mode '0644'
     variables(
       name: new_resource.name,
       listen: new_resource.listen,
@@ -47,7 +47,7 @@ end
 action :enable do
   if @current_resource.exists
     execute "nxensite #{new_resource.name}" do
-      command "#{node["nginx"]["bin_dir"]}/nxensite #{new_resource.name}"
+      command "#{node['nginx']['bin_dir']}/nxensite #{new_resource.name}"
       not_if { ::File.exist?(nginx_enabled_file) }
     end
   else
@@ -58,7 +58,7 @@ end
 action :disable do
   if @current_resource.exists
     execute "nxdissite #{new_resource.name}" do
-      command "#{node["nginx"]["bin_dir"]}/nxdissite #{new_resource.name}"
+      command "#{node['nginx']['bin_dir']}/nxdissite #{new_resource.name}"
       only_if { ::File.exist?(nginx_enabled_file) }
     end
   else
@@ -74,11 +74,11 @@ def load_current_resource
 end
 
 def nginx_available_file
-  "#{node["nginx"]["dir"]}/sites-available/#{new_resource.name}"
+  "#{node['nginx']['dir']}/sites-available/#{new_resource.name}"
 end
 
 def nginx_enabled_file
-  "#{node["nginx"]["dir"]}/sites-enabled/#{new_resource.name}"
+  "#{node['nginx']['dir']}/sites-enabled/#{new_resource.name}"
 end
 
 def log_missing_resource

--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -3,73 +3,73 @@
 # Recipe:: configuration
 #
 
-[node["nginx"]["dir"], node["nginx"]["log_dir"]].each do |dir|
+[node['nginx']['dir'], node['nginx']['log_dir']].each do |dir|
   directory dir do
-    owner "root"
-    group "root"
-    mode "0755"
+    owner 'root'
+    group 'root'
+    mode '0755'
     recursive true
   end
 end
 
-cookbook_file "#{node["nginx"]["dir"]}/mime.types" do
-  source "mime.types"
-  owner "root"
-  group "root"
-  mode  "0644"
-  notifies :restart, "service[nginx]"
+cookbook_file "#{node['nginx']['dir']}/mime.types" do
+  source 'mime.types'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[nginx]'
 end
 
-template "nginx.conf" do
-  path "#{node["nginx"]["dir"]}/nginx.conf"
-  source "nginx.conf.erb"
-  owner "root"
-  group "root"
-  mode  "0644"
-  notifies :restart, "service[nginx]"
+template 'nginx.conf' do
+  path "#{node['nginx']['dir']}/nginx.conf"
+  source 'nginx.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[nginx]'
 end
 
 %w[sites-available sites-enabled].each do |vhost_dir|
-  directory "#{node["nginx"]["dir"]}/#{vhost_dir}" do
-    owner  "root"
-    group  "root"
-    mode   "0755"
+  directory "#{node['nginx']['dir']}/#{vhost_dir}" do
+    owner 'root'
+    group 'root'
+    mode '0755'
     action :create
   end
 end
 
-nginx_site "default" do
-  host node["hostname"]
-  root "/var/www/nginx-default"
-  not_if { node["nginx"]["skip_default_site"] }
+nginx_site 'default' do
+  host node['hostname']
+  root '/var/www/nginx-default'
+  not_if { node['nginx']['skip_default_site'] }
 end
 
 # ensure default site is removed if necessary
 %w[enabled available].each do |dir|
-  file "#{node["nginx"]["dir"]}/sites-#{dir}/default" do
+  file "#{node['nginx']['dir']}/sites-#{dir}/default" do
     action :delete
-    only_if { node["nginx"]["skip_default_site"] }
-    notifies :restart, "service[nginx]"
+    only_if { node['nginx']['skip_default_site'] }
+    notifies :restart, 'service[nginx]'
   end
 end
 
-node["nginx"]["conf_files"].each do |config_file|
+node['nginx']['conf_files'].each do |config_file|
   template config_file do
-    path "#{node["nginx"]["dir"]}/conf.d/#{config_file}.conf"
+    path "#{node['nginx']['dir']}/conf.d/#{config_file}.conf"
     source "#{config_file}.conf.erb"
-    owner "root"
-    group "root"
-    mode  "0644"
-    notifies :restart, "service[nginx]"
+    owner 'root'
+    group 'root'
+    mode '0644'
+    notifies :restart, 'service[nginx]'
   end
 end
 
-template "#{node["nginx"]["dir"]}/conf.d/nginx_status.conf" do
-  source "nginx_status.conf.erb"
-  owner "root"
-  group "root"
-  mode "0644"
-  notifies :restart, "service[nginx]"
-  variables(port: node["nginx"]["status_port"])
-  only_if { node["nginx"]["enable_stub_status"] }
+template "#{node['nginx']['dir']}/conf.d/nginx_status.conf" do
+  source 'nginx_status.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[nginx]'
+  variables(port: node['nginx']['status_port'])
+  only_if { node['nginx']['enable_stub_status'] }
 end

--- a/recipes/debug.rb
+++ b/recipes/debug.rb
@@ -3,9 +3,9 @@
 # Recipe:: debug
 #
 
-include_recipe "nginx"
+include_recipe 'nginx'
 
-package "nginx-debug"
+package 'nginx-debug'
 
-include_recipe "nginx::configuration"
-include_recipe "nginx::service"
+include_recipe 'nginx::configuration'
+include_recipe 'nginx::service'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,14 +3,21 @@
 # Recipe:: default
 #
 
-repo = node["nginx"]["repository_sources"].fetch(node["nginx"]["repository"])
+repo = node['nginx']['repository_sources'].fetch(node['nginx']['repository'])
 
-apt_repository "nginx" do
-  uri repo["uri"]
-  distribution repo["distribution"]
-  components repo["components"]
-  key repo["key"]
-  keyserver repo["keyserver"] if repo["keyserver"]
-  deb_src repo["deb_src"]
-  action :add
+case node['platform_family']
+when 'debian'
+  apt_repository 'nginx' do
+    uri repo['uri']
+    distribution repo['distribution']
+    components repo['components']
+    key repo['key']
+    keyserver repo['keyserver'] if repo['keyserver']
+    deb_src repo['deb_src']
+    action :add
+  end
+when 'rhel'
+  include_recipe 'yum-nginx::default'
+else
+  fail("Platform family #{node['platform_family']} is not supported.")
 end

--- a/recipes/enabledisablesite.rb
+++ b/recipes/enabledisablesite.rb
@@ -3,21 +3,21 @@
 # Recipe:: enabledisablesite
 #
 
-template "#{node["nginx"]["bin_dir"]}/nxensite" do
-  source "nxensite.erb"
-  owner "root"
-  group "root"
-  mode "0755"
+template "#{node['nginx']['bin_dir']}/nxensite" do
+  source 'nxensite.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
 end
 
-link "#{node["nginx"]["bin_dir"]}/nxdissite" do
-  to "#{node["nginx"]["bin_dir"]}/nxensite"
-  only_if { ::File.exist?("#{node["nginx"]["bin_dir"]}/nxensite") }
+link "#{node['nginx']['bin_dir']}/nxdissite" do
+  to "#{node['nginx']['bin_dir']}/nxensite"
+  only_if { ::File.exist?("#{node['nginx']['bin_dir']}/nxensite") }
 end
 
-template "/etc/bash_completion.d/nxendissite" do
-  source "nxendissite_completion.erb"
-  owner "root"
-  group "root"
-  mode "0644"
+template '/etc/bash_completion.d/nxendissite' do
+  source 'nxendissite_completion.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -3,18 +3,18 @@
 # Recipe:: server
 #
 
-include_recipe "nginx"
+include_recipe 'nginx'
 
 # ensure config files don't get trampled by chef
-package "nginx-common" do
+package 'nginx-common' do
   options %(-o Dpkg::Options::="--force-confdef")
-  only_if { %w[ppa phusion].include?(node["nginx"]["repository"]) }
+  only_if { %w[ppa phusion].include?(node['nginx']['repository']) }
 end
 
-package node["nginx"]["package_name"] do
-  version node["nginx"]["version"]
+package node['nginx']['package_name'] do
+  version node['nginx']['version']
 end
 
-include_recipe "nginx::service"
-include_recipe "nginx::configuration"
-include_recipe "nginx::enabledisablesite"
+include_recipe 'nginx::service'
+include_recipe 'nginx::configuration'
+include_recipe 'nginx::enabledisablesite'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -3,7 +3,7 @@
 # Recipe:: service
 #
 
-service "nginx" do
+service 'nginx' do
   supports status: true, restart: true, reload: true
   action [:enable, :start]
 end

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -8,15 +8,15 @@ actions :create, :delete, :enable, :disable
 default_action :create
 
 attribute :name, kind_of: String, name_attribute: true
-attribute :listen, kind_of: String, default: "80"
-attribute :host, kind_of: String, default: "localhost"
-attribute :root, kind_of: String, default: "/var/www"
-attribute :index, kind_of: String, default: "index.html index.htm"
-attribute :location, kind_of: String, default: "try_files $uri $uri/"
+attribute :listen, kind_of: String, default: '80'
+attribute :host, kind_of: String, default: 'localhost'
+attribute :root, kind_of: String, default: '/var/www'
+attribute :index, kind_of: String, default: 'index.html index.htm'
+attribute :location, kind_of: String, default: 'try_files $uri $uri/'
 attribute :phpfpm, kind_of: [TrueClass, FalseClass], default: false
 attribute :access_log, kind_of: [TrueClass, FalseClass], default: true
 attribute :custom_data, kind_of: Hash, default: {}
-attribute :template_cookbook, kind_of: String, default: "nginx"
-attribute :template_source, kind_of: String, default: "site.erb"
+attribute :template_cookbook, kind_of: String, default: 'nginx'
+attribute :template_source, kind_of: String, default: 'site.erb'
 
 attr_accessor :exists

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,106 +1,106 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "nginx::configuration" do
+describe 'nginx::configuration' do
   let(:chef_run) do
-    ChefSpec::SoloRunner.new.converge(described_recipe, "nginx::service")
+    ChefSpec::SoloRunner.new.converge(described_recipe, 'nginx::service')
   end
 
-  it "creates the configuration directory" do
-    expect(chef_run).to create_directory("/etc/nginx").with(
-      owner: "root",
-      group: "root",
+  it 'creates the configuration directory' do
+    expect(chef_run).to create_directory('/etc/nginx').with(
+      owner: 'root',
+      group: 'root',
       recursive: true
     )
   end
 
-  it "creates the `mime.types` file" do
-    expect(chef_run).to create_cookbook_file("/etc/nginx/mime.types").with(
-      source: "mime.types",
-      owner: "root",
-      group: "root",
-      mode:  "0644"
+  it 'creates the `mime.types` file' do
+    expect(chef_run).to create_cookbook_file('/etc/nginx/mime.types').with(
+      source: 'mime.types',
+      owner: 'root',
+      group: 'root',
+      mode:  '0644'
     )
 
-    file = chef_run.cookbook_file("/etc/nginx/mime.types")
-    expect(file).to notify("service[nginx]").to(:restart)
+    file = chef_run.cookbook_file('/etc/nginx/mime.types')
+    expect(file).to notify('service[nginx]').to(:restart)
   end
 
-  it "creates the log directory" do
-    expect(chef_run).to create_directory("/var/log/nginx").with(
-      owner: "root",
-      group: "root",
+  it 'creates the log directory' do
+    expect(chef_run).to create_directory('/var/log/nginx').with(
+      owner: 'root',
+      group: 'root',
       recursive: true
     )
   end
 
-  it "creates the `nginx.conf` template" do
-    expect(chef_run).to create_template("/etc/nginx/nginx.conf").with(
-      source: "nginx.conf.erb",
-      owner: "root",
-      group: "root",
-      mode:  "0644"
+  it 'creates the `nginx.conf` template' do
+    expect(chef_run).to create_template('/etc/nginx/nginx.conf').with(
+      source: 'nginx.conf.erb',
+      owner: 'root',
+      group: 'root',
+      mode:  '0644'
     )
 
-    file = chef_run.template("/etc/nginx/nginx.conf")
-    expect(file).to notify("service[nginx]").to(:restart)
+    file = chef_run.template('/etc/nginx/nginx.conf')
+    expect(file).to notify('service[nginx]').to(:restart)
   end
 
   %w[sites-available sites-enabled].each do |vhost_dir|
     it "creates the `#{vhost_dir}` directory" do
       expect(chef_run).to create_directory("/etc/nginx/#{vhost_dir}").with(
-        owner: "root",
-        group: "root",
-        mode: "0755"
+        owner: 'root',
+        group: 'root',
+        mode: '0755'
       )
     end
   end
 
-  context "default site" do
+  context 'default site' do
     let(:default_site) do
-      "default"
+      'default'
     end
 
-    context "when `skip_default_site` is false" do
+    context 'when `skip_default_site` is false' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
-          node.automatic_attrs["hostname"] = "chefspechostname"
-        end.converge(described_recipe, "nginx::service")
+          node.automatic_attrs['hostname'] = 'chefspechostname'
+        end.converge(described_recipe, 'nginx::service')
       end
 
-      it "creates the `default` template" do
+      it 'creates the `default` template' do
         expect(chef_run).to create_nginx_site(default_site).with(
-          host: "chefspechostname",
-          root: "/var/www/nginx-default"
+          host: 'chefspechostname',
+          root: '/var/www/nginx-default'
         )
       end
 
-      it "does not remove the default site configuration" do
+      it 'does not remove the default site configuration' do
         expect(chef_run).to_not delete_file(
-          "/etc/nginx/sites-available/default"
+          '/etc/nginx/sites-available/default'
         )
-        expect(chef_run).to_not delete_file("/etc/nginx/sites-enabled/default")
+        expect(chef_run).to_not delete_file('/etc/nginx/sites-enabled/default')
       end
     end
 
-    context "when `skip_default_site` is true" do
+    context 'when `skip_default_site` is true' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
-          node.set["nginx"]["skip_default_site"] = true
-        end.converge(described_recipe, "nginx::service")
+          node.set['nginx']['skip_default_site'] = true
+        end.converge(described_recipe, 'nginx::service')
       end
 
-      it "does not create the `default` template" do
+      it 'does not create the `default` template' do
         expect(chef_run).to_not create_template(default_site)
       end
 
-      it "removes the default site configuration" do
-        expect(chef_run).to delete_file("/etc/nginx/sites-available/default")
-        expect(chef_run).to delete_file("/etc/nginx/sites-enabled/default")
+      it 'removes the default site configuration' do
+        expect(chef_run).to delete_file('/etc/nginx/sites-available/default')
+        expect(chef_run).to delete_file('/etc/nginx/sites-enabled/default')
       end
     end
   end
 
-  context "conf.d entries" do
+  context 'conf.d entries' do
     let(:custom_entries) do
       %w[foo bar baz]
     end
@@ -109,48 +109,48 @@ describe "nginx::configuration" do
       %w[buffers general gzip logs performance proxy ssl_session timeouts]
     end
 
-    context "cookbook defaults" do
-      it "creates the default templates" do
+    context 'cookbook defaults' do
+      it 'creates the default templates' do
         default_entries.each do |entry|
           conf_file = "/etc/nginx/conf.d/#{entry}.conf"
 
           expect(chef_run).to create_template(conf_file).with(
             source: "#{entry}.conf.erb",
-            owner: "root",
-            group: "root",
-            mode:  "0644"
+            owner: 'root',
+            group: 'root',
+            mode:  '0644'
           )
 
           tmpl = chef_run.template(conf_file)
-          expect(tmpl).to notify("service[nginx]").to(:restart)
+          expect(tmpl).to notify('service[nginx]').to(:restart)
         end
       end
     end
 
-    context "custom attributes" do
+    context 'custom attributes' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
-          node.set["nginx"]["conf_files"] = %w[foo bar baz]
-        end.converge(described_recipe, "nginx::service")
+          node.set['nginx']['conf_files'] = %w[foo bar baz]
+        end.converge(described_recipe, 'nginx::service')
       end
 
-      it "creates the custom templates" do
+      it 'creates the custom templates' do
         custom_entries.each do |entry|
           conf_file = "/etc/nginx/conf.d/#{entry}.conf"
 
           expect(chef_run).to create_template(conf_file).with(
             source: "#{entry}.conf.erb",
-            owner: "root",
-            group: "root",
-            mode:  "0644"
+            owner: 'root',
+            group: 'root',
+            mode:  '0644'
           )
 
           tmpl = chef_run.template(conf_file)
-          expect(tmpl).to notify("service[nginx]").to(:restart)
+          expect(tmpl).to notify('service[nginx]').to(:restart)
         end
       end
 
-      it "does not create the default templates" do
+      it 'does not create the default templates' do
         default_entries.each do |entry|
           conf_file = "/etc/nginx/conf.d/#{entry}.conf"
 
@@ -160,34 +160,34 @@ describe "nginx::configuration" do
     end
   end
 
-  context "nginx status" do
+  context 'nginx status' do
     let(:status_conf) do
-      "/etc/nginx/conf.d/nginx_status.conf"
+      '/etc/nginx/conf.d/nginx_status.conf'
     end
 
-    context "when `enable_stub_status` is true" do
-      it "creates the `nginx_status.conf` template" do
+    context 'when `enable_stub_status` is true' do
+      it 'creates the `nginx_status.conf` template' do
         expect(chef_run).to create_template(status_conf).with(
-          source: "nginx_status.conf.erb",
-          owner: "root",
-          group: "root",
-          mode: "0644",
+          source: 'nginx_status.conf.erb',
+          owner: 'root',
+          group: 'root',
+          mode: '0644',
           variables: { port: 80 }
         )
 
         tmpl = chef_run.template(status_conf)
-        expect(tmpl).to notify("service[nginx]").to(:restart)
+        expect(tmpl).to notify('service[nginx]').to(:restart)
       end
     end
 
-    context "when `enable_stub_status` is false" do
+    context 'when `enable_stub_status` is false' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
-          node.set["nginx"]["enable_stub_status"] = false
-        end.converge(described_recipe, "nginx::service")
+          node.set['nginx']['enable_stub_status'] = false
+        end.converge(described_recipe, 'nginx::service')
       end
 
-      it "does not create the `nginx_status.conf` template" do
+      it 'does not create the `nginx_status.conf` template' do
         expect(chef_run).to_not create_template(status_conf)
       end
     end

--- a/spec/debug_spec.rb
+++ b/spec/debug_spec.rb
@@ -1,14 +1,14 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "nginx::debug" do
+describe 'nginx::debug' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new.converge(described_recipe)
   end
 
-  it { expect(chef_run).to include_recipe("nginx::default") }
+  it { expect(chef_run).to include_recipe('nginx::default') }
 
-  it { expect(chef_run).to install_package("nginx-debug") }
+  it { expect(chef_run).to install_package('nginx-debug') }
 
-  it { expect(chef_run).to include_recipe("nginx::configuration") }
-  it { expect(chef_run).to include_recipe("nginx::service") }
+  it { expect(chef_run).to include_recipe('nginx::configuration') }
+  it { expect(chef_run).to include_recipe('nginx::service') }
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,17 +1,17 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "nginx::default" do
+describe 'nginx::default' do
   let(:apt_source) do
-    "/etc/apt/sources.list.d/nginx.list"
+    '/etc/apt/sources.list.d/nginx.list'
   end
 
-  context "official source" do
+  context 'official source' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new.converge(described_recipe)
     end
 
     it "sets up the 'official' repository" do
-      expect(chef_run).to add_apt_repository("nginx")
+      expect(chef_run).to add_apt_repository('nginx')
 
       # expect(chef_run).to(
       #   render_file(apt_source).with_content(
@@ -21,15 +21,15 @@ describe "nginx::default" do
     end
   end
 
-  context "ppa source" do
+  context 'ppa source' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set["nginx"]["repository"] = "ppa"
+        node.set['nginx']['repository'] = 'ppa'
       end.converge(described_recipe)
     end
 
     it "sets up the 'ppa' repository" do
-      expect(chef_run).to add_apt_repository("nginx")
+      expect(chef_run).to add_apt_repository('nginx')
 
       # expect(chef_run).to(
       #   render_file(apt_source).with_content(
@@ -39,15 +39,15 @@ describe "nginx::default" do
     end
   end
 
-  context "phusion source" do
+  context 'phusion source' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set["nginx"]["repository"] = "phusion"
+        node.set['nginx']['repository'] = 'phusion'
       end.converge(described_recipe)
     end
 
     it "sets up the 'phusion' repository" do
-      expect(chef_run).to add_apt_repository("nginx")
+      expect(chef_run).to add_apt_repository('nginx')
 
       # expect(chef_run).to(
       #   render_file(apt_source).with_content(
@@ -57,14 +57,14 @@ describe "nginx::default" do
     end
   end
 
-  context "invalid source" do
+  context 'invalid source' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set["nginx"]["repository"] = "invalid"
+        node.set['nginx']['repository'] = 'invalid'
       end.converge(described_recipe)
     end
 
-    it "raises an exception" do
+    it 'raises an exception' do
       expect(-> { chef_run }).to raise_error(KeyError)
     end
   end

--- a/spec/enabledisablesite_spec.rb
+++ b/spec/enabledisablesite_spec.rb
@@ -1,44 +1,44 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "nginx::enabledisablesite" do
+describe 'nginx::enabledisablesite' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new.converge(described_recipe)
   end
 
-  it "creates the `nxensite` script" do
+  it 'creates the `nxensite` script' do
     allow(File).to receive(:exist?).with(anything).and_call_original
-    allow(File).to receive(:exist?).with("/usr/sbin/nxensite").and_return(false)
+    allow(File).to receive(:exist?).with('/usr/sbin/nxensite').and_return(false)
 
-    expect(chef_run).to create_template("/usr/sbin/nxensite").with(
-      source: "nxensite.erb",
-      owner: "root",
-      group: "root",
-      mode:  "0755"
+    expect(chef_run).to create_template('/usr/sbin/nxensite').with(
+      source: 'nxensite.erb',
+      owner: 'root',
+      group: 'root',
+      mode:  '0755'
     )
   end
 
-  it "creates the `nxdissite` link" do
+  it 'creates the `nxdissite` link' do
     allow(File).to receive(:exist?).with(anything).and_call_original
-    allow(File).to receive(:exist?).with("/usr/sbin/nxensite").and_return(true)
-    allow(File).to receive(:symlink?).with("/usr/sbin/nxdissite")
+    allow(File).to receive(:exist?).with('/usr/sbin/nxensite').and_return(true)
+    allow(File).to receive(:symlink?).with('/usr/sbin/nxdissite')
       .and_return(false)
 
-    expect(chef_run).to create_link("/usr/sbin/nxdissite").with(
-      to: "/usr/sbin/nxensite"
+    expect(chef_run).to create_link('/usr/sbin/nxdissite').with(
+      to: '/usr/sbin/nxensite'
     )
   end
 
-  it "creates bash completion `nxendissite`" do
-    completion_file = "/etc/bash_completion.d/nxendissite"
+  it 'creates bash completion `nxendissite`' do
+    completion_file = '/etc/bash_completion.d/nxendissite'
 
     allow(File).to receive(:exist?).with(anything).and_call_original
     allow(File).to receive(:exist?).with(completion_file).and_return(false)
 
     expect(chef_run).to create_template(completion_file).with(
-      source: "nxendissite_completion.erb",
-      owner: "root",
-      group: "root",
-      mode:  "0644"
+      source: 'nxendissite_completion.erb',
+      owner: 'root',
+      group: 'root',
+      mode:  '0644'
     )
   end
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,58 +1,58 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "nginx::server" do
+describe 'nginx::server' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new.converge(described_recipe)
   end
 
   specify do
-    expect(chef_run).to include_recipe("nginx::default")
+    expect(chef_run).to include_recipe('nginx::default')
 
-    expect(chef_run).to install_package("nginx")
-    expect(chef_run).to_not install_package("nginx-common")
+    expect(chef_run).to install_package('nginx')
+    expect(chef_run).to_not install_package('nginx-common')
 
-    expect(chef_run).to include_recipe("nginx::configuration")
-    expect(chef_run).to include_recipe("nginx::service")
-    expect(chef_run).to include_recipe("nginx::enabledisablesite")
+    expect(chef_run).to include_recipe('nginx::configuration')
+    expect(chef_run).to include_recipe('nginx::service')
+    expect(chef_run).to include_recipe('nginx::enabledisablesite')
   end
 
-  context "with a specific `package_name` and `version`" do
+  context 'with a specific `package_name` and `version`' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set["nginx"]["package_name"] = "nginx-chefspec"
-        node.set["nginx"]["version"] = "1.2.3"
+        node.set['nginx']['package_name'] = 'nginx-chefspec'
+        node.set['nginx']['version'] = '1.2.3'
       end.converge(described_recipe)
     end
 
-    it "installs the specified package and version" do
+    it 'installs the specified package and version' do
       expect(chef_run).to(
-        install_package("nginx-chefspec").with_version("1.2.3")
+        install_package('nginx-chefspec').with_version('1.2.3')
       )
     end
   end
 
-  context "with `ppa` or `phusion` repository sources" do
-    context "ppa" do
+  context 'with `ppa` or `phusion` repository sources' do
+    context 'ppa' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
-          node.set["nginx"]["repository"] = "ppa"
+          node.set['nginx']['repository'] = 'ppa'
         end.converge(described_recipe)
       end
 
       specify do
-        expect(chef_run).to install_package "nginx-common"
+        expect(chef_run).to install_package 'nginx-common'
       end
     end
 
-    context "phusion" do
+    context 'phusion' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
-          node.set["nginx"]["repository"] = "phusion"
+          node.set['nginx']['repository'] = 'phusion'
         end.converge(described_recipe)
       end
 
       specify do
-        expect(chef_run).to install_package "nginx-common"
+        expect(chef_run).to install_package 'nginx-common'
       end
     end
   end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -1,10 +1,10 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "nginx::server" do
+describe 'nginx::server' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new.converge(described_recipe)
   end
 
-  it { expect(chef_run).to enable_service("nginx") }
-  it { expect(chef_run).to start_service("nginx") }
+  it { expect(chef_run).to enable_service('nginx') }
+  it { expect(chef_run).to start_service('nginx') }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,15 @@
 begin
-  require "rspec/expectations"
-  require "chefspec"
-  require "chefspec/berkshelf"
+  require 'rspec/expectations'
+  require 'chefspec'
+  require 'chefspec/berkshelf'
 rescue LoadError
-  puts "Unable to run `chefspec`"
+  puts 'Unable to run `chefspec`'
   exit
 end
 
 RSpec.configure do |config|
-  config.platform = "ubuntu"
-  config.version = "12.04"
+  config.platform = 'ubuntu'
+  config.version = '12.04'
   config.log_level = :error
 end
 

--- a/test/integration/server/serverspec/server_spec.rb
+++ b/test/integration/server/serverspec/server_spec.rb
@@ -1,126 +1,126 @@
-require "serverspec"
+require 'serverspec'
 
 set :backend, :exec
 
-describe "nginx::server" do
-  describe package("nginx") do
+describe 'nginx::server' do
+  describe package('nginx') do
     it { should be_installed }
   end
 end
 
-describe "nginx::configuration" do
-  describe file("/etc/nginx/mime.types") do
+describe 'nginx::configuration' do
+  describe file('/etc/nginx/mime.types') do
     it { should be_a_file }
-    it { should be_owned_by "root" }
-    it { should be_grouped_into "root" }
-    it { should be_mode "644" }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode '644' }
   end
 
-  describe file("/etc/nginx/nginx.conf") do
+  describe file('/etc/nginx/nginx.conf') do
     it { should be_a_file }
-    it { should be_owned_by "root" }
-    it { should be_grouped_into "root" }
-    it { should be_mode "644" }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode '644' }
   end
 
-  describe file("/etc/nginx/conf.d/nginx_status.conf") do
+  describe file('/etc/nginx/conf.d/nginx_status.conf') do
     it { should be_a_file }
-    it { should be_owned_by "root" }
-    it { should be_grouped_into "root" }
-    it { should be_mode "644" }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode '644' }
   end
 
-  describe "default conf.d templates" do
-    describe file("/etc/nginx/conf.d/buffers.conf") do
+  describe 'default conf.d templates' do
+    describe file('/etc/nginx/conf.d/buffers.conf') do
       it { should be_a_file }
-      it { should be_owned_by "root" }
-      it { should be_grouped_into "root" }
-      it { should be_mode "644" }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode '644' }
     end
 
-    describe file("/etc/nginx/conf.d/general.conf") do
+    describe file('/etc/nginx/conf.d/general.conf') do
       it { should be_a_file }
-      it { should be_owned_by "root" }
-      it { should be_grouped_into "root" }
-      it { should be_mode "644" }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode '644' }
     end
 
-    describe file("/etc/nginx/conf.d/gzip.conf") do
+    describe file('/etc/nginx/conf.d/gzip.conf') do
       it { should be_a_file }
-      it { should be_owned_by "root" }
-      it { should be_grouped_into "root" }
-      it { should be_mode "644" }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode '644' }
     end
 
-    describe file("/etc/nginx/conf.d/logs.conf") do
+    describe file('/etc/nginx/conf.d/logs.conf') do
       it { should be_a_file }
-      it { should be_owned_by "root" }
-      it { should be_grouped_into "root" }
-      it { should be_mode "644" }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode '644' }
     end
 
-    describe file("/etc/nginx/conf.d/performance.conf") do
+    describe file('/etc/nginx/conf.d/performance.conf') do
       it { should be_a_file }
-      it { should be_owned_by "root" }
-      it { should be_grouped_into "root" }
-      it { should be_mode "644" }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode '644' }
     end
 
-    describe file("/etc/nginx/conf.d/proxy.conf") do
+    describe file('/etc/nginx/conf.d/proxy.conf') do
       it { should be_a_file }
-      it { should be_owned_by "root" }
-      it { should be_grouped_into "root" }
-      it { should be_mode "644" }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode '644' }
     end
 
-    describe file("/etc/nginx/conf.d/ssl_session.conf") do
+    describe file('/etc/nginx/conf.d/ssl_session.conf') do
       it { should be_a_file }
-      it { should be_owned_by "root" }
-      it { should be_grouped_into "root" }
-      it { should be_mode "644" }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode '644' }
     end
 
-    describe file("/etc/nginx/conf.d/timeouts.conf") do
+    describe file('/etc/nginx/conf.d/timeouts.conf') do
       it { should be_a_file }
-      it { should be_owned_by "root" }
-      it { should be_grouped_into "root" }
-      it { should be_mode "644" }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode '644' }
     end
   end
 
-  describe "directories" do
-    describe file("/var/log/nginx") do
+  describe 'directories' do
+    describe file('/var/log/nginx') do
       it { should be_directory }
-      it { should be_owned_by "root" }
-      it { should be_grouped_into "root" }
-      it { should be_mode "755" }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode '755' }
     end
 
-    describe file("/etc/nginx/sites-available") do
+    describe file('/etc/nginx/sites-available') do
       it { should be_directory }
-      it { should be_owned_by "root" }
-      it { should be_grouped_into "root" }
-      it { should be_mode "755" }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode '755' }
     end
 
-    describe file("/etc/nginx/sites-enabled") do
+    describe file('/etc/nginx/sites-enabled') do
       it { should be_directory }
-      it { should be_owned_by "root" }
-      it { should be_grouped_into "root" }
-      it { should be_mode "755" }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode '755' }
     end
   end
 
-  describe file("/etc/nginx/sites-available/default") do
+  describe file('/etc/nginx/sites-available/default') do
     it { should be_a_file }
-    it { should be_owned_by "root" }
-    it { should be_grouped_into "root" }
-    it { should be_mode "644" }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode '644' }
   end
 end
 
-describe "nginx::service" do
-  describe service("nginx") do
+describe 'nginx::service' do
+  describe service('nginx') do
     it { should be_enabled }
     it { should be_running }
   end
@@ -130,22 +130,22 @@ describe "nginx::service" do
   end
 end
 
-describe "nginx::enabledisablesite" do
-  describe file("/usr/sbin/nxensite") do
+describe 'nginx::enabledisablesite' do
+  describe file('/usr/sbin/nxensite') do
     it { should be_a_file }
-    it { should be_owned_by "root" }
-    it { should be_grouped_into "root" }
-    it { should be_mode "755" }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode '755' }
   end
 
-  describe file("/usr/sbin/nxdissite") do
-    it { should be_linked_to "/usr/sbin/nxensite" }
+  describe file('/usr/sbin/nxdissite') do
+    it { should be_linked_to '/usr/sbin/nxensite' }
   end
 
-  describe file("/etc/bash_completion.d/nxendissite") do
+  describe file('/etc/bash_completion.d/nxendissite') do
     it { should be_a_file }
-    it { should be_owned_by "root" }
-    it { should be_grouped_into "root" }
-    it { should be_mode "644" }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode '644' }
   end
 end


### PR DESCRIPTION
- Support for CentOS, tested against CentOS 6.7
- Verify test coverage on CentOS
- Removed ssh configuration in kitchen, files not included with repo
- Rubocop changes
  - Max Line Length = 200
  - Change double quote to single quote and replace interpolation and quoting rubocop lines
